### PR TITLE
from whenMethod to when

### DIFF
--- a/src/v2/Mockit.ts
+++ b/src/v2/Mockit.ts
@@ -30,7 +30,7 @@ export class Mockit {
     return new AbstractClassMock<T>(propertiesToMock) as T;
   }
 
-  static whenMethod<T>(method: any) {
+  static when<T>(method: any) {
     return {
       /**
        * This function sets up the behaviour of the mocked method.

--- a/src/v2/__tests__/mocks/abstract.spec.ts
+++ b/src/v2/__tests__/mocks/abstract.spec.ts
@@ -8,20 +8,18 @@ abstract class Hellaw {
 describe("v2", () => {
   it("should setup default behaviour for abstract method", async () => {
     const returningMock = Mockit.mockAbstract(Hellaw, ["hello"]);
-    Mockit.whenMethod(returningMock.hello).isCalled.thenReturn("world");
+    Mockit.when(returningMock.hello).isCalled.thenReturn("world");
 
     expect(returningMock.hello("hello")).toBe("world");
 
     const throwingMock = Mockit.mockAbstract(Hellaw, ["hello"]);
-    Mockit.whenMethod(throwingMock.hello).isCalled.thenThrow(
-      new Error("error")
-    );
+    Mockit.when(throwingMock.hello).isCalled.thenThrow(new Error("error"));
 
     expect(() => throwingMock.hello("hello")).toThrowError("error");
 
     let counter = 0;
     const callingMock = Mockit.mockAbstract(Hellaw, ["hello"]);
-    Mockit.whenMethod(callingMock.hello).isCalled.thenCall(() => {
+    Mockit.when(callingMock.hello).isCalled.thenCall(() => {
       counter++;
     });
 
@@ -32,15 +30,13 @@ describe("v2", () => {
     expect(counter).toBe(3);
 
     const resolvingMock = Mockit.mockAbstract(Hellaw, ["hello"]);
-    Mockit.whenMethod(resolvingMock.hello).isCalled.thenResolve(
-      "world-resolved"
-    );
+    Mockit.when(resolvingMock.hello).isCalled.thenResolve("world-resolved");
 
     const resolved = await resolvingMock.hello("hello");
     expect(resolved).toBe("world-resolved");
 
     const rejectingMock = Mockit.mockAbstract(Hellaw, ["hello"]);
-    Mockit.whenMethod(rejectingMock.hello).isCalled.thenReject(
+    Mockit.when(rejectingMock.hello).isCalled.thenReject(
       new Error("error-rejected")
     );
 

--- a/src/v2/__tests__/mocks/class.spec.ts
+++ b/src/v2/__tests__/mocks/class.spec.ts
@@ -37,14 +37,14 @@ describe("v2 class", () => {
 
   it("should allow to change the default behaviour", async () => {
     const mock = Mockit.mock(Hellaw);
-    Mockit.whenMethod(mock.hello).isCalled.thenReturn("hello");
+    Mockit.when(mock.hello).isCalled.thenReturn("hello");
     expect(mock.hello()).toBe("hello");
 
-    Mockit.whenMethod(mock.world).isCalled.thenThrow(new Error("error"));
+    Mockit.when(mock.world).isCalled.thenThrow(new Error("error"));
     expect(() => mock.world()).toThrowError("error");
 
     let counter = 0;
-    Mockit.whenMethod(mock.helloworld).isCalled.thenCall(() => {
+    Mockit.when(mock.helloworld).isCalled.thenCall(() => {
       counter++;
     });
 
@@ -54,10 +54,10 @@ describe("v2 class", () => {
     mock.helloworld();
     expect(counter).toBe(3);
 
-    Mockit.whenMethod(mock.helloworld).isCalled.thenResolve("hello-resolved");
+    Mockit.when(mock.helloworld).isCalled.thenResolve("hello-resolved");
     expect(mock.helloworld()).resolves.toBe("hello-resolved");
 
-    Mockit.whenMethod(mock.helloworld).isCalled.thenReject(
+    Mockit.when(mock.helloworld).isCalled.thenReject(
       new Error("error-rejected")
     );
     expect(mock.helloworld()).rejects.toThrowError("error-rejected");

--- a/src/v2/__tests__/mocks/customBehaviour.spec.ts
+++ b/src/v2/__tests__/mocks/customBehaviour.spec.ts
@@ -14,10 +14,10 @@ describe("v2 function custom behaviour", () => {
 
   test("mockit should be able to specify arguments related behaviours", () => {
     const mock = Mockit.mockFunction(hello);
-    Mockit.whenMethod(mock).isCalledWith("hello").thenReturn("hello");
-    Mockit.whenMethod(mock).isCalledWith("world").thenReturn("world");
-    Mockit.whenMethod(mock).isCalledWith().thenReturn("undefinedinput");
-    Mockit.whenMethod(mock).isCalled.thenReturn("default");
+    Mockit.when(mock).isCalledWith("hello").thenReturn("hello");
+    Mockit.when(mock).isCalledWith("world").thenReturn("world");
+    Mockit.when(mock).isCalledWith().thenReturn("undefinedinput");
+    Mockit.when(mock).isCalled.thenReturn("default");
 
     expect(mock("hello")).toBe("hello");
     expect(mock("world")).toBe("world");
@@ -25,10 +25,10 @@ describe("v2 function custom behaviour", () => {
     expect(mock({ az: 2, y: 3 })).toBe("default");
 
     const throwingMock = Mockit.mockFunction(hello);
-    Mockit.whenMethod(throwingMock).isCalledWith("hello").thenThrow("hello");
-    Mockit.whenMethod(throwingMock).isCalledWith("world").thenThrow("world");
-    Mockit.whenMethod(throwingMock).isCalledWith().thenThrow("undefinedinput");
-    Mockit.whenMethod(throwingMock).isCalled.thenThrow("default");
+    Mockit.when(throwingMock).isCalledWith("hello").thenThrow("hello");
+    Mockit.when(throwingMock).isCalledWith("world").thenThrow("world");
+    Mockit.when(throwingMock).isCalledWith().thenThrow("undefinedinput");
+    Mockit.when(throwingMock).isCalled.thenThrow("default");
 
     expect(() => throwingMock("hello")).toThrow("hello");
     expect(() => throwingMock("world")).toThrow("world");
@@ -37,18 +37,18 @@ describe("v2 function custom behaviour", () => {
 
     const counter = { value: 0 };
     const callingMock = Mockit.mockFunction(hello);
-    Mockit.whenMethod(callingMock)
+    Mockit.when(callingMock)
       .isCalledWith("hello")
       .thenCall(() => {
         counter.value++;
       });
-    Mockit.whenMethod(callingMock)
+    Mockit.when(callingMock)
       .isCalledWith("world")
       .thenCall(() => {
         counter.value--;
       });
 
-    Mockit.whenMethod(callingMock).isCalled.thenCall(() => {
+    Mockit.when(callingMock).isCalled.thenCall(() => {
       counter.value = 9999;
     });
 
@@ -67,12 +67,10 @@ describe("v2 function custom behaviour", () => {
     expect(counter.value).toBe(9999);
 
     const resolvingMock = Mockit.mockFunction(hello);
-    Mockit.whenMethod(resolvingMock).isCalledWith("hello").thenResolve("hello");
-    Mockit.whenMethod(resolvingMock).isCalledWith("world").thenResolve("world");
-    Mockit.whenMethod(resolvingMock)
-      .isCalledWith()
-      .thenResolve("undefinedinput");
-    Mockit.whenMethod(resolvingMock).isCalled.thenResolve("default");
+    Mockit.when(resolvingMock).isCalledWith("hello").thenResolve("hello");
+    Mockit.when(resolvingMock).isCalledWith("world").thenResolve("world");
+    Mockit.when(resolvingMock).isCalledWith().thenResolve("undefinedinput");
+    Mockit.when(resolvingMock).isCalled.thenResolve("default");
 
     expect(resolvingMock("hello")).resolves.toBe("hello");
     expect(resolvingMock("world")).resolves.toBe("world");
@@ -80,12 +78,10 @@ describe("v2 function custom behaviour", () => {
     expect(resolvingMock({ az: 2, y: 3 })).resolves.toBe("default");
 
     const rejectingMock = Mockit.mockFunction(hello);
-    Mockit.whenMethod(rejectingMock).isCalledWith("hello").thenReject("hello");
-    Mockit.whenMethod(rejectingMock).isCalledWith("world").thenReject("world");
-    Mockit.whenMethod(rejectingMock)
-      .isCalledWith()
-      .thenReject("undefinedinput");
-    Mockit.whenMethod(rejectingMock).isCalled.thenReject("default");
+    Mockit.when(rejectingMock).isCalledWith("hello").thenReject("hello");
+    Mockit.when(rejectingMock).isCalledWith("world").thenReject("world");
+    Mockit.when(rejectingMock).isCalledWith().thenReject("undefinedinput");
+    Mockit.when(rejectingMock).isCalled.thenReject("default");
 
     expect(rejectingMock("hello")).rejects.toBe("hello");
     expect(rejectingMock("world")).rejects.toBe("world");
@@ -96,15 +92,15 @@ describe("v2 function custom behaviour", () => {
   it("should be able to specific different behaviours for the same function", () => {
     const mock = Mockit.mockFunction(hello);
     let counter = 0;
-    Mockit.whenMethod(mock).isCalledWith("hello").thenReturn("hello");
-    Mockit.whenMethod(mock).isCalledWith("world").thenThrow("world");
-    Mockit.whenMethod(mock)
+    Mockit.when(mock).isCalledWith("hello").thenReturn("hello");
+    Mockit.when(mock).isCalledWith("world").thenThrow("world");
+    Mockit.when(mock)
       .isCalledWith()
       .thenCall(() => {
         counter++;
       });
-    Mockit.whenMethod(mock).isCalled.thenResolve("default");
-    Mockit.whenMethod(mock).isCalledWith("NOOO").thenReject("NOOO");
+    Mockit.when(mock).isCalled.thenResolve("default");
+    Mockit.when(mock).isCalledWith("NOOO").thenReject("NOOO");
 
     expect(mock("hello")).toBe("hello");
     expect(() => mock("world")).toThrow("world");

--- a/src/v2/__tests__/mocks/function.spec.ts
+++ b/src/v2/__tests__/mocks/function.spec.ts
@@ -15,14 +15,14 @@ describe("v2 function", () => {
 
   it("should allow to change the default behaviour", async () => {
     const mock = Mockit.mockFunction(hellaw);
-    Mockit.whenMethod(mock).isCalled.thenReturn("hello");
+    Mockit.when(mock).isCalled.thenReturn("hello");
     expect(mock()).toBe("hello");
 
-    Mockit.whenMethod(mock).isCalled.thenThrow(new Error("error"));
+    Mockit.when(mock).isCalled.thenThrow(new Error("error"));
     expect(() => mock()).toThrowError("error");
 
     let counter = 0;
-    Mockit.whenMethod(mock).isCalled.thenCall(() => {
+    Mockit.when(mock).isCalled.thenCall(() => {
       counter++;
     });
 
@@ -32,10 +32,10 @@ describe("v2 function", () => {
     mock();
     expect(counter).toBe(3);
 
-    Mockit.whenMethod(mock).isCalled.thenResolve("hello-resolved");
+    Mockit.when(mock).isCalled.thenResolve("hello-resolved");
     expect(mock()).resolves.toBe("hello-resolved");
 
-    Mockit.whenMethod(mock).isCalled.thenReject(new Error("hello-rejected"));
+    Mockit.when(mock).isCalled.thenReject(new Error("hello-rejected"));
     expect(mock()).rejects.toThrowError("hello-rejected");
   });
 });

--- a/src/v2/__tests__/spy/calls.spec.ts
+++ b/src/v2/__tests__/spy/calls.spec.ts
@@ -37,7 +37,7 @@ describe("v2 stats", () => {
     expect(spy.calls.length).toBe(3);
 
     let counter = 0;
-    Mockit.whenMethod(mock)
+    Mockit.when(mock)
       .isCalledWith("hiiii")
       .thenCall(() => counter++);
 

--- a/src/v2/__tests__/spy/withArgs.hasBeenCalledX.spec.ts
+++ b/src/v2/__tests__/spy/withArgs.hasBeenCalledX.spec.ts
@@ -6,7 +6,7 @@ describe("V2 hasBeenCalledWith", () => {
   it("should provide functions asserting if a method has been called at least once with a specific set of arguments", () => {
     const mock = Mockit.mockFunction(hello);
     const spy = Mockit.spy(mock);
-    Mockit.whenMethod(mock)
+    Mockit.when(mock)
       .isCalledWith("hello")
       .thenCall(() => "world");
 
@@ -45,7 +45,7 @@ describe("V2 hasBeenCalledWith", () => {
   it("should provide functions asserting how many times a method has been called with a specific set of arguments", () => {
     const mock = Mockit.mockFunction(hello);
     const spy = Mockit.spy(mock);
-    Mockit.whenMethod(mock)
+    Mockit.when(mock)
       .isCalledWith("hello")
       .thenCall(() => "world");
 


### PR DESCRIPTION
This pull request proposes to change the name of the `whenMethod` function to simply `when`, effectively shortening it. The original function name was longer as I had initially intended to divide `whenXXX` into separate methods. However, I have since been able to consolidate all of the necessary functionality into a single function, rendering the longer name unnecessary.