### PR TITLE
Feature/suppose verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,14 +336,14 @@ Mockit.when(mock).isCalledWith(z.schema({
 }).thenReturn("minor");
 ```
 
-I also want to implement a `verify` API directly with the mock, so that you can do something like:
+- [x] I also want to implement a `verify` API directly with the mock, so that you can do something like: (IT WORKS \o/)
 
 ```ts
 // IDEA ONLY: THIS IS NOT AVAILABLE
 function hello(...args: any[]) {}
 
 const mock = Mockit.mock(hello);
-mockExpect(mock).isCalledWith(
+suppose(mock).willBeCalledWith(
   z.schema({
     name: z.string(),
     email: z.email(),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vdcode/mockit",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "description": "mocking library experiment",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/__tests__/verify/verify.spec.ts
+++ b/src/__tests__/verify/verify.spec.ts
@@ -1,0 +1,69 @@
+import { z } from "zod";
+import { mockFunction, suppose, verify } from "../../mockit";
+
+function hello(..._args: any[]) {}
+
+describe("suppose then verify", () => {
+  it("should pass if the function has been called at least once", () => {
+    const mock = mockFunction(hello);
+    suppose(mock).willBeCalled.atLeastOnce;
+
+    mock();
+    verify(mock);
+  });
+
+  it("should throw if the function has not been called", () => {
+    const mock = mockFunction(hello);
+    suppose(mock).willBeCalled.atLeastOnce;
+
+    expect(() => verify(mock)).toThrow();
+  });
+
+  it("should pass allow multiple suppositions", () => {
+    const mock = mockFunction(hello);
+    suppose(mock).willBeCalled.atLeastOnce;
+    suppose(mock).willBeCalled.twice;
+
+    mock();
+    mock();
+    verify(mock);
+  });
+
+  it("should not pass if the function has not been called enough times", () => {
+    const mock = mockFunction(hello);
+    suppose(mock).willBeCalled.twice;
+
+    mock();
+    expect(() => verify(mock)).toThrow();
+
+    mock();
+    verify(mock);
+  });
+
+  it("should work with specific arguments", () => {
+    const mock = mockFunction(hello);
+    suppose(mock).willBeCalledWith("hello").once;
+
+    mock("hello");
+    verify(mock);
+
+    suppose(mock).willBeCalledWith(2).atLeastOnce;
+    expect(() => verify(mock)).toThrow();
+
+    mock(2);
+    verify(mock);
+  });
+
+  it("should accept zod schemas", () => {
+    const mock = mockFunction(hello);
+    suppose(mock).willBeCalledWith(z.number()).once;
+
+    mock(2);
+    verify(mock);
+
+    suppose(mock).willBeCalledWith(z.string()).once;
+
+    mock("hello");
+    verify(mock);
+  });
+});

--- a/src/__tests__/verify/verify.spec.ts
+++ b/src/__tests__/verify/verify.spec.ts
@@ -66,4 +66,38 @@ describe("suppose then verify", () => {
     mock("hello");
     verify(mock);
   });
+
+  it("should accept multiple complex arguments on multiple suppositions", () => {
+    const mock = mockFunction(hello);
+    suppose(mock).willBeCalledWith(z.number(), z.string()).once;
+    suppose(mock).willBeCalledWith(z.string(), z.number()).once;
+    suppose(mock).willBeCalledWith(
+      z.object({
+        hello: z.string(),
+        world: z.number(),
+        todayIs: z.date(),
+      })
+    ).twice;
+
+    mock(2, "hello");
+    expect(() => verify(mock)).toThrow(); // only one supposition is valid
+
+    mock("hello", 2);
+    expect(() => verify(mock)).toThrow(); // only two supposition are valid
+
+    mock({
+      hello: "hello",
+      world: 2,
+      todayIs: new Date(),
+    });
+    expect(() => verify(mock)).toThrow(); // the last supposition is not complete: it needs another call
+
+    mock({
+      hello: "hello",
+      world: 2,
+      todayIs: new Date(),
+    });
+
+    verify(mock);
+  });
 });

--- a/src/functionMock/getCatch.ts
+++ b/src/functionMock/getCatch.ts
@@ -1,5 +1,6 @@
 import { HashingMap } from "../HashingMap";
 import { FunctionCalls } from "../functionSpy";
+import { SuppositionRegistry } from "../suppose";
 
 export function getCatch(target, prop, _receiver) {
   switch (prop) {
@@ -13,6 +14,12 @@ export function getCatch(target, prop, _receiver) {
     case "callsMap":
       const callsMap = Reflect.get(target, "callsMap") as FunctionCalls;
       return callsMap;
+    case "suppositionsMap":
+      const suppositionsMap = Reflect.get(
+        target,
+        "suppositionsMap"
+      ) as SuppositionRegistry;
+      return suppositionsMap;
     default:
       throw new Error("Unauthorized property");
   }

--- a/src/functionMock/index.ts
+++ b/src/functionMock/index.ts
@@ -7,6 +7,7 @@ import { getCatch } from "./getCatch";
 import { setCatch } from "./setCatch";
 
 import { FunctionMockUtils } from "./utils";
+import { SuppositionRegistry } from "../suppose";
 
 export const Behaviours = {
   Return: "Return",
@@ -70,6 +71,7 @@ export function initializeProxy(proxy: any, functionName: string) {
     calls: [],
     mockMap: new HashingMap(),
     callsMap: new FunctionCalls(),
+    suppositionsMap: new SuppositionRegistry(),
   });
 }
 

--- a/src/functionMock/setCatch.ts
+++ b/src/functionMock/setCatch.ts
@@ -8,6 +8,7 @@ export function setCatch(target, prop, newValue, receiver) {
     Reflect.set(target, "functionName", newValue.functionName);
     Reflect.set(target, "mockMap", newValue.mockMap);
     Reflect.set(target, "callsMap", newValue.callsMap);
+    Reflect.set(target, "suppositionsMap", newValue.suppositionsMap);
     return true;
   }
 

--- a/src/mockit.ts
+++ b/src/mockit.ts
@@ -8,6 +8,8 @@ import { FunctionMock } from "./functionMock";
 import { FunctionMockUtils } from "./functionMock/utils";
 
 import { FunctionSpy } from "./functionSpy";
+import { suppose } from "./suppose";
+import { verify } from "./suppose/verify";
 
 type AbstractClass<T> = abstract new (...args: any[]) => T;
 export type Class<T> = new (...args: any[]) => T;
@@ -45,6 +47,8 @@ export function when<T>(method: any) {
     },
   };
 }
+
+export { suppose, verify };
 
 export function spy<T extends (...args: any[]) => any>(
   mockedFunctionInstance: T
@@ -89,6 +93,9 @@ export class Mockit {
     // This generic type is here to make it look like it accepts a real function
     return spy(mockedFunctionInstance);
   }
+
+  static suppose = suppose;
+  static verify = verify;
 
   static get any() {
     // this is just a port to zod, you can pass zod schemas directly

--- a/src/suppose/index.ts
+++ b/src/suppose/index.ts
@@ -1,0 +1,92 @@
+export type SuppositionCount = "atLeastOnce" | number;
+export type Supposition = {
+  args: any[] | undefined;
+  count: SuppositionCount;
+};
+
+export class SuppositionRegistry {
+  private suppositions: Supposition[] = [];
+
+  public addSupposition(supposition: Supposition) {
+    this.suppositions.push(supposition);
+  }
+
+  public getSuppositions() {
+    return this.suppositions;
+  }
+}
+
+export function suppose(mock: any) {
+  const suppositionsMap = Reflect.get(
+    mock,
+    "suppositionsMap"
+  ) as SuppositionRegistry;
+  return {
+    willBeCalled: {
+      get atLeastOnce() {
+        return suppositionsMap.addSupposition({
+          args: undefined,
+          count: "atLeastOnce",
+        });
+      },
+      get once() {
+        return suppositionsMap.addSupposition({
+          args: undefined,
+          count: 1,
+        });
+      },
+      get twice() {
+        return suppositionsMap.addSupposition({
+          args: undefined,
+          count: 2,
+        });
+      },
+      get thrice() {
+        return suppositionsMap.addSupposition({
+          args: undefined,
+          count: 3,
+        });
+      },
+      nTimes(n: number) {
+        return suppositionsMap.addSupposition({
+          args: undefined,
+          count: n,
+        });
+      },
+    },
+    willBeCalledWith(...args: any[]) {
+      return {
+        get atLeastOnce() {
+          return suppositionsMap.addSupposition({
+            args,
+            count: "atLeastOnce",
+          });
+        },
+        get once() {
+          return suppositionsMap.addSupposition({
+            args,
+            count: 1,
+          });
+        },
+        get twice() {
+          return suppositionsMap.addSupposition({
+            args,
+            count: 2,
+          });
+        },
+        get thrice() {
+          return suppositionsMap.addSupposition({
+            args,
+            count: 3,
+          });
+        },
+        nTimes(n: number) {
+          return suppositionsMap.addSupposition({
+            args,
+            count: n,
+          });
+        },
+      };
+    },
+  };
+}

--- a/src/suppose/verify.ts
+++ b/src/suppose/verify.ts
@@ -1,0 +1,35 @@
+import { FunctionSpy } from "../functionSpy";
+import { SuppositionRegistry } from ".";
+
+export function verify(mock: any) {
+  const suppositions = Reflect.get(
+    mock,
+    "suppositionsMap"
+  ) as SuppositionRegistry;
+
+  const spy = new FunctionSpy(mock);
+  const analysis = suppositions.getSuppositions().map((supposition) => {
+    if (supposition.count === "atLeastOnce") {
+      if (supposition.args == null) {
+        return spy.hasBeenCalled.atLeastOnce;
+      }
+
+      return spy.hasBeenCalled.withArgs(...supposition.args).atLeastOnce;
+    }
+
+    if (supposition.args == null) {
+      return spy.hasBeenCalled.nTimes(supposition.count);
+    }
+
+    return spy.hasBeenCalled
+      .withArgs(...supposition.args)
+      .nTimes(supposition.count);
+  });
+
+  if (analysis.some((a) => a === false)) {
+    throw new Error("Verification failed");
+  }
+
+  // TODO: beautiful error message with lots of details
+  // TODO: safeVerify that does not throw but instead returns the analysis with details
+}


### PR DESCRIPTION
This PR adds a really good feature: the ability to make assertions on how the mock **_will be called_**, and to verify it with one simple function call.

It's nothing new actually, and uses the existing mock & spy helpers as building blocks. It works very well with zod because of that.

This gives you quite a bit of asserting power with the help of two new functions: `suppose` (i did not want to use expect or assert to avoid conflicts with testing frameworks) and `verify`.

```ts
it("should accept multiple complex arguments on multiple suppositions", () => {
    const mock = mockFunction(hello);
    suppose(mock).willBeCalledWith(z.number(), z.string()).once;
    suppose(mock).willBeCalledWith(z.string(), z.number()).once;
    suppose(mock).willBeCalledWith(
      z.object({
        hello: z.string(),
        world: z.number(),
        todayIs: z.date(),
      })
    ).twice;

    mock(2, "hello");
    expect(() => verify(mock)).toThrow(); // only one supposition is valid

    mock("hello", 2);
    expect(() => verify(mock)).toThrow(); // only two supposition are valid

    mock({
      hello: "hello",
      world: 2,
      todayIs: new Date(),
    });
    expect(() => verify(mock)).toThrow(); // the last supposition is not complete: it needs another call

    mock({
      hello: "hello",
      world: 2,
      todayIs: new Date(),
    });

    verify(mock);
});
```